### PR TITLE
Add: Stand-alone concurrency and callback function for cache misses

### DIFF
--- a/byteview.go
+++ b/byteview.go
@@ -1,0 +1,28 @@
+package geecache
+
+// ByteView 缓存值结构体，只读
+type ByteView struct {
+	b []byte // 缓存的真实值，为支持任意类型的数据类型的存储采用byte类型
+}
+
+// Len 由于Value接口的需要，ByteView必须实现Len方法
+func (bv ByteView) Len() int {
+	return len(bv.b)
+}
+
+// ByteSlice ByteView只读，为防止修改只返回拷贝值
+func (bv ByteView) ByteSlice() []byte {
+	return cloneBytes(bv.b)
+}
+
+// cloneBytes 深复制，返回b的拷贝
+func cloneBytes(b []byte) []byte {
+	c := make([]byte, len(b))
+	copy(c, b)
+	return c
+}
+
+// String 返回bv.b的字符串形式
+func (bv ByteView) String() string {
+	return string(bv.b)
+}

--- a/cache.go
+++ b/cache.go
@@ -1,0 +1,39 @@
+package geecache
+
+import (
+	"geecache/lru"
+	"sync"
+)
+
+// cache 将lru.Cache的方法封装为单机可并行的（可对外部开放的主要是Add和Get两个方法）
+type cache struct {
+	mu         sync.Mutex
+	lru        *lru.Cache
+	cacheBytes int64
+}
+
+// add lru.Add的封装，由于cache本身没有初始化函数，故将lru为nil时lru的创建一起封装
+// 这被称为延迟初始化(Lazy Initialization)
+func (c *cache) add(key string, value ByteView) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.lru == nil { // cache本身没有
+		c.lru = lru.New(c.cacheBytes, nil)
+	}
+	c.lru.Add(key, value)
+}
+
+// get
+func (c *cache) get(key string) (value ByteView, ok bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.lru == nil {
+		return
+	} else {
+		if v, ok := c.lru.Get(key); ok {
+			// value类型转换
+			return v.(ByteView), ok
+		}
+		return
+	}
+}

--- a/geecache.go
+++ b/geecache.go
@@ -1,0 +1,103 @@
+package geecache
+
+import (
+	"fmt"
+	"log"
+	"sync"
+)
+
+// Getter Getter接口，含义一个方法：回调函数Get
+type Getter interface {
+	Get(key string) ([]byte, error)
+}
+
+// GetterFunc 函数类型，定义其参数和返回值格式
+type GetterFunc func(key string) ([]byte, error)
+
+// Get GetterFunc类型的方法Get
+func (f GetterFunc) Get(key string) ([]byte, error) {
+	return f(key)
+}
+
+//如此实现接口Getter是为了接口使用的便利性
+//	func GetFromSource(getter Getter, key string) []byte {
+//		buf, err := getter.Get(key)
+//		if err == nil {
+//			return buf
+//		}
+//		return nil
+//	}
+//比如以上函数，getter既可以传入GetterFunc类型的匿名函数或者可以转化为GetterFunc类型的普通函数，
+//还可以传入实现了Get方法的结构体。
+
+// Group 某一个缓存的命名空间
+type Group struct {
+	name      string // 唯一名称
+	getter    Getter // 缓存未命中时调用的回调接口
+	mainCache cache  // 并发缓存
+}
+
+var (
+	mu     sync.RWMutex              // 全局/系统读写锁
+	groups = make(map[string]*Group) // group字典，保存系统所有Group地址
+)
+
+// NewGroup Group的创建/初始化函数，返回一个Group指针
+func NewGroup(name string, cacheBytes int64, getter Getter) *Group {
+	if getter == nil {
+		panic("nil getter") // 当错误条件（我们所测试的代码）很严苛且不可恢复，程序不能继续运行时，可以使用 panic() 函数产生一个中止程序的运行时错误
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	g := &Group{
+		name:      name,
+		getter:    getter,
+		mainCache: cache{cacheBytes: cacheBytes},
+	}
+	groups[name] = g
+	return g
+}
+
+// GetGroup 从groups字典中获得需要的Group指针
+func GetGroup(name string) *Group {
+	mu.RLock()
+	g := groups[name] // 存在获得nil的情况
+	mu.RUnlock()
+	return g
+}
+
+// Get 从缓存系统中获取缓存值，并对缓存命中，未命中情况处理（目前未命中只有单机实现）
+func (g *Group) Get(key string) (ByteView, error) {
+	if key == "" {
+		return ByteView{}, fmt.Errorf("nil key")
+	}
+
+	// 缓存命中
+	if v, ok := g.mainCache.get(key); ok {
+		log.Printf("key: %s hit cache", key)
+		return v, nil
+	}
+
+	// 缓存未命中
+	return g.load(key)
+}
+
+func (g *Group) load(key string) (ByteView, error) {
+	// 单机情况，只需要从本节点数据源获取
+	return g.getLocally(key)
+}
+
+func (g *Group) getLocally(key string) (ByteView, error) {
+	bytesValue, err := g.getter.Get(key)
+	if err != nil {
+		return ByteView{}, err
+	}
+	value := ByteView{b: cloneBytes(bytesValue)} // 注意深拷贝，否则后续对value.b操作可能会影响到原始缓存
+	g.populateCache(key, value)                  //用这个函数而不直接使用g.mainCache.add可能是为了分布式扩展
+	return value, nil
+}
+
+// populateCache 在g.mainCache添加新键值对
+func (g *Group) populateCache(key string, value ByteView) {
+	g.mainCache.add(key, value)
+}

--- a/geecache_test.go
+++ b/geecache_test.go
@@ -1,0 +1,42 @@
+package geecache
+
+import (
+	"fmt"
+	"log"
+	"testing"
+)
+
+var db = map[string]string{
+	"Tom":  "630",
+	"Jack": "589",
+	"Sam":  "567",
+}
+
+func TestGet(t *testing.T) {
+	loadCounts := make(map[string]int, len(db))
+	gee := NewGroup("scores", 2<<10, GetterFunc(
+		func(key string) ([]byte, error) {
+			log.Println("[SlowDB] search key", key)
+			if v, ok := db[key]; ok {
+				if _, ok := loadCounts[key]; !ok {
+					loadCounts[key] = 0
+				}
+				loadCounts[key] += 1
+				return []byte(v), nil
+			}
+			return nil, fmt.Errorf("%s not exist", key)
+		}))
+
+	for k, v := range db {
+		if view, err := gee.Get(k); err != nil || view.String() != v {
+			t.Fatal("failed to get value of Tom")
+		} // load from callback function
+		if _, err := gee.Get(k); err != nil || loadCounts[k] > 1 {
+			t.Fatalf("cache %s miss", k)
+		} // cache hit
+	}
+
+	if view, err := gee.Get("unknown"); err == nil {
+		t.Fatalf("the value of unknow should be empty, but %s got", view)
+	}
+}


### PR DESCRIPTION
Implemented a stand-alone concurrency encapsulation around the LRU Cache Architecture;
Implemented the Getter interface, including a callback function method that is called when the cache misses;
Implemented the Group structure, which is an abstraction of a cache in the caching system, and can complete the logical control of the cache entity from the receipt of the Key to the return of the Value.